### PR TITLE
Fix-formatting-and-lints

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,40 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Dart
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Note: This workflow uses the latest stable version of the Dart SDK.
+      # You can specify other versions if desired, see documentation here:
+      # https://github.com/dart-lang/setup-dart/blob/main/README.md
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Install dependencies
+        run: dart pub get
+
+      # Uncomment this step to verify the use of 'dart format' on each commit.
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      # Consider passing '--fatal-infos' for slightly stricter analysis.
+      - name: Analyze project source
+        run: dart analyze
+
+      # Your project will need to have tests in test/ and a dependency on
+      # package:test for this step to succeed.
+      - name: Run tests
+        run: dart test

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,14 +1,26 @@
-# Defines a default set of lint rules enforced for
-# projects at Google. For details and rationale,
-# see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
-
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
-# Uncomment to specify additional rules.
-# linter:
-#   rules:
-#     - camel_case_types
+include: package:lints/recommended.yaml
 
 analyzer:
-  enable-experiment:
-    - non-nullable
+  language:
+    # would be good to turn these on in future
+    strict-inference: false
+    strict-casts: false
+    strict-raw-types: false
+  errors:
+    todo: ignore
+
+linter:
+  rules:
+    camel_case_types: false
+    non_constant_identifier_names: false
+    always_put_control_body_on_new_line: false
+    curly_braces_in_flow_control_structures: false
+    prefer_final_locals: false
+    constant_identifier_names: false
+    avoid_renaming_method_parameters: false
+    prefer_function_declarations_over_variables: false
+    avoid_function_literals_in_foreach_calls: false
+
+
+
+   

--- a/bin/dart_eval.dart
+++ b/bin/dart_eval.dart
@@ -95,6 +95,7 @@ void main(List<String> args) {
     final dbc = File(command['path']!).readAsBytesSync();
     final runtime = Runtime(dbc.buffer.asByteData());
     runtime.setup();
+    // ignore: deprecated_member_use_from_same_package
     var result = runtime.executeNamed(0, 'main');
 
     if (result != null) {

--- a/lib/src/eval/bridge/declaration/type.dart
+++ b/lib/src/eval/bridge/declaration/type.dart
@@ -1,4 +1,3 @@
-import 'package:dart_eval/src/eval/compiler/type.dart';
 import 'package:dart_eval/src/eval/shared/types.dart';
 import 'package:json_annotation/json_annotation.dart';
 

--- a/lib/src/eval/bridge/runtime_bridge.dart
+++ b/lib/src/eval/bridge/runtime_bridge.dart
@@ -1,6 +1,5 @@
 import 'package:dart_eval/dart_eval_bridge.dart';
 import 'package:dart_eval/src/eval/runtime/runtime.dart';
-import 'package:dart_eval/src/eval/shared/stdlib/core/base.dart';
 
 /// A bridge class can be extended inside the dart_eval VM and used both in and outside of it.
 mixin $Bridge<T> on Object implements $Value, $Instance {

--- a/lib/src/eval/compiler/collection/set_map.dart
+++ b/lib/src/eval/compiler/collection/set_map.dart
@@ -53,8 +53,6 @@ Variable compileSetOrMapLiteral(SetOrMapLiteral l, CompilerContext ctx) {
 
 Pair<Variable, List<Pair<TypeRef, TypeRef>>> compileSetOrMapElement(CollectionElement e, Variable? setOrMap,
     CompilerContext ctx, TypeRef? specifiedKeyType, TypeRef? specifiedValueType, bool box) {
-  final isMap = setOrMap?.type.resolveTypeChain(ctx).isAssignableTo(ctx, EvalTypes.mapType);
-
   if (e is Expression) {
     throw CompileError('Sets are not currently supported');
   } else if (e is MapLiteralEntry) {

--- a/lib/src/eval/compiler/compiler.dart
+++ b/lib/src/eval/compiler/compiler.dart
@@ -397,7 +397,7 @@ class Compiler {
   TypeRef? _cacheTypeRef(int libraryIndex, DeclarationOrBridge declarationOrBridge) {
     if (declarationOrBridge.isBridge) {
       final bridge = declarationOrBridge.bridge;
-      if (!(bridge is BridgeClassDef)) {
+      if (bridge is! BridgeClassDef) {
         return null;
       }
       if (bridge.type.type.cacheId != null) {
@@ -407,7 +407,7 @@ class Compiler {
       return TypeRef.cache(ctx, libraryIndex, spec.name, fileRef: libraryIndex);
     } else {
       final declaration = declarationOrBridge.declaration!;
-      if (!(declaration is ClassDeclaration)) {
+      if (declaration is! ClassDeclaration) {
         return null;
       }
       return TypeRef.cache(ctx, libraryIndex, declaration.name.name, fileRef: libraryIndex);
@@ -452,7 +452,7 @@ class Compiler {
     if (!ctx.bridgeStaticFunctionIndices.containsKey(libraryIndex)) {
       ctx.bridgeStaticFunctionIndices[libraryIndex] = <String, int>{};
     }
-    ctx.bridgeStaticFunctionIndices[libraryIndex]!['${functionDef.name}'] = _bridgeStaticFunctionIdx++;
+    ctx.bridgeStaticFunctionIndices[libraryIndex]![functionDef.name] = _bridgeStaticFunctionIdx++;
   }
 }
 

--- a/lib/src/eval/compiler/context.dart
+++ b/lib/src/eval/compiler/context.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: body_might_complete_normally_nullable
+
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:dart_eval/source_node_wrapper.dart';
 import 'package:dart_eval/src/eval/compiler/constant_pool.dart';
@@ -230,11 +232,6 @@ class CompilerContext with ScopeContext {
     }
     scopeDoesClose.removeLast();
     return super.endAllocScope(popValues: popValues, popAdjust: popAdjust);
-  }
-
-  @override
-  void resetStack({int position = 0}) {
-    super.resetStack(position: position);
   }
 
   int rewriteOp(int where, EvcOp newOp, int lengthAdjust) {

--- a/lib/src/eval/compiler/declaration/constructor.dart
+++ b/lib/src/eval/compiler/declaration/constructor.dart
@@ -92,6 +92,7 @@ void compileConstructorDeclaration(
   if ($extends == null) {
     $super = BuiltinValue().push(ctx);
   } else {
+    // ignore: deprecated_member_use
     extendsWhat = ctx.visibleDeclarations[ctx.library]![$extends.superclass2.name.name]!;
 
     final decl = extendsWhat.declaration!;
@@ -165,8 +166,7 @@ void compileConstructorDeclaration(
     for (final field in fd.fields.variables) {
       if (!usedNames.contains(field.name.name) && field.initializer != null) {
         final V = compileExpression(field.initializer!, ctx).boxIfNeeded(ctx);
-        ctx.pushOp(SetObjectPropertyImpl.make(instOffset, _fieldIdx, V.scopeFrameOffset),
-            SetObjectPropertyImpl.LEN);
+        ctx.pushOp(SetObjectPropertyImpl.make(instOffset, _fieldIdx, V.scopeFrameOffset), SetObjectPropertyImpl.LEN);
       }
       _fieldIdx++;
     }
@@ -177,6 +177,7 @@ void compileConstructorDeclaration(
     final bridge = decl.bridge! as BridgeClassDef;
 
     if (!bridge.bridge) {
+      // ignore: deprecated_member_use
       throw CompileError('Bridge class ${$extends.superclass2} is a wrapper, not a bridge, so you can\'t extend it');
     }
 
@@ -190,7 +191,9 @@ void compileConstructorDeclaration(
       namedArgTypes.addAll(_namedArgs.map((key, value) => MapEntry(key, value.type)));
     }
 
-    final op = BridgeInstantiate.make(instOffset,
+    final op = BridgeInstantiate.make(
+        instOffset,
+        // ignore: deprecated_member_use
         ctx.bridgeStaticFunctionIndices[decl.sourceLib]!['${$extends.superclass2.name.name}.$constructorName']!);
     ctx.pushOp(op, BridgeInstantiate.len(op));
     final bridgeInst = Variable.alloc(ctx, EvalTypes.dynamicType);

--- a/lib/src/eval/compiler/declaration/declaration.dart
+++ b/lib/src/eval/compiler/declaration/declaration.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: body_might_complete_normally_nullable
+
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:dart_eval/src/eval/compiler/context.dart';
 import 'package:dart_eval/src/eval/compiler/declaration/class.dart';

--- a/lib/src/eval/compiler/expression/identifier.dart
+++ b/lib/src/eval/compiler/expression/identifier.dart
@@ -22,7 +22,7 @@ Reference compileIdentifierAsReference(Identifier id, CompilerContext ctx) {
       if (!ctx.instanceDeclarationsMap[L.type.file]!.containsKey(L.type.name)) {
         final idn = id.identifier.name;
         final tl = ctx.topLevelDeclarationsMap[L.type.file]![L.type.name]!;
-        if (!tl.isBridge || !(tl.bridge is BridgeClassDef)) {
+        if (!tl.isBridge || tl.bridge is! BridgeClassDef) {
           throw UnimplementedError('Trying to access ${id.prefix}.$idn on ${L.type}, which is not a class');
         }
         final cls = tl.bridge as BridgeClassDef;
@@ -67,6 +67,7 @@ Pair<TypeRef, DeclarationOrBridge>? resolveInstanceDeclaration(
   }
   final $classDec = _$classDec.declaration! as ClassDeclaration;
   if ($classDec.withClause != null) {
+    // ignore: deprecated_member_use
     for (final $mixin in $classDec.withClause!.mixinTypes2) {
       final mixinType = ctx.visibleTypes[library]![$mixin.name.name]!;
       final result = resolveInstanceDeclaration(ctx, mixinType.file, mixinType.name, name);
@@ -76,6 +77,7 @@ Pair<TypeRef, DeclarationOrBridge>? resolveInstanceDeclaration(
     }
   }
   if ($classDec.extendsClause != null) {
+    // ignore: deprecated_member_use
     final extendsType = ctx.visibleTypes[library]![$classDec.extendsClause!.superclass2.name.name]!;
     return resolveInstanceDeclaration(ctx, extendsType.file, extendsType.name, name);
   }

--- a/lib/src/eval/compiler/expression/keywords.dart
+++ b/lib/src/eval/compiler/expression/keywords.dart
@@ -20,6 +20,7 @@ Variable compileSuperExpression(SuperExpression e, CompilerContext ctx) {
   var type = EvalTypes.objectType;
   final extendsClause = ctx.currentClass!.extendsClause;
   if (extendsClause != null) {
+    // ignore: deprecated_member_use
     type = ctx.visibleTypes[ctx.library]![extendsClause.superclass2.name.name]!;
   }
 

--- a/lib/src/eval/compiler/expression/method_invocation.dart
+++ b/lib/src/eval/compiler/expression/method_invocation.dart
@@ -1,6 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:dart_eval/dart_eval_bridge.dart';
-import 'package:dart_eval/src/eval/bridge/declaration/class.dart';
 import 'package:dart_eval/src/eval/compiler/builtins.dart';
 import 'package:dart_eval/src/eval/compiler/context.dart';
 import 'package:dart_eval/src/eval/compiler/errors.dart';
@@ -188,10 +187,7 @@ Variable _invokeWithTarget(CompilerContext ctx, Variable L, MethodInvocation e) 
 
   ctx.pushOp(PushReturnValue.make(), PushReturnValue.LEN);
 
-  final v = Variable.alloc(
-      ctx,
-      mReturnType?.type?.copyWith(boxed: true) ??
-          EvalTypes.dynamicType);
+  final v = Variable.alloc(ctx, mReturnType?.type?.copyWith(boxed: true) ?? EvalTypes.dynamicType);
 
   return v;
 }
@@ -214,6 +210,7 @@ DeclarationOrBridge<MethodDeclaration, BridgeMethodDef> resolveInstanceMethod(
     if ($class.extendsClause == null) {
       throw CompileError('Cannot resolve instance method');
     }
+    // ignore: deprecated_member_use
     final $supertype = ctx.visibleTypes[instanceType.file]![$class.extendsClause!.superclass2.name.name]!;
     return resolveInstanceMethod(ctx, $supertype, methodName);
   }

--- a/lib/src/eval/compiler/helpers/argument_list.dart
+++ b/lib/src/eval/compiler/helpers/argument_list.dart
@@ -185,12 +185,12 @@ Pair<List<Variable>, Map<String, Variable>> compileArgumentListWithBridge(
 
 TypeRef _resolveFieldFormalType(
     CompilerContext ctx, int decLibrary, FieldFormalParameter param, Declaration parameterHost) {
-  if (!(parameterHost is ConstructorDeclaration)) {
+  if (parameterHost is! ConstructorDeclaration) {
     throw CompileError('Field formals can only occur in constructors');
   }
   final $class = parameterHost.parent as ClassDeclaration;
   final field = ctx.instanceDeclarationsMap[decLibrary]![$class.name.name]![param.identifier.name]!;
-  if (!(field is VariableDeclaration)) {
+  if (field is! VariableDeclaration) {
     throw CompileError('Resolved field is not a FieldDeclaration');
   }
   final vdl = field.parent as VariableDeclarationList;

--- a/lib/src/eval/compiler/optimizer/prescan.dart
+++ b/lib/src/eval/compiler/optimizer/prescan.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: body_might_complete_normally_nullable
+
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:dart_eval/dart_eval_bridge.dart';

--- a/lib/src/eval/compiler/reference.dart
+++ b/lib/src/eval/compiler/reference.dart
@@ -209,7 +209,7 @@ class IdentifierReference implements Reference {
       return Variable.alloc(ctx, type);
     }
 
-    if (!(decl is FunctionDeclaration) && !(decl is ConstructorDeclaration)) {
+    if (decl is! FunctionDeclaration && decl is! ConstructorDeclaration) {
       decl as ClassDeclaration;
 
       final returnType = TypeRef.lookupClassDeclaration(ctx, _decl.sourceLib, decl);
@@ -293,7 +293,7 @@ class IdentifierReference implements Reference {
 
     final decl = _decl.declaration!;
 
-    if (!(decl is FunctionDeclaration) && !(decl is ConstructorDeclaration)) {
+    if (decl is! FunctionDeclaration && decl is! ConstructorDeclaration) {
       decl as ClassDeclaration;
 
       final DeferredOrOffset offset;

--- a/lib/src/eval/compiler/statement/for.dart
+++ b/lib/src/eval/compiler/statement/for.dart
@@ -9,7 +9,7 @@ import 'package:dart_eval/src/eval/compiler/type.dart';
 StatementInfo compileForStatement(ForStatement s, CompilerContext ctx, AlwaysReturnType? expectedReturnType) {
   final parts = s.forLoopParts;
 
-  if (!(parts is ForParts)) {
+  if (parts is! ForParts) {
     throw UnimplementedError('For-each is not supported yet');
   }
 

--- a/lib/src/eval/compiler/type.dart
+++ b/lib/src/eval/compiler/type.dart
@@ -1,6 +1,7 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:dart_eval/dart_eval_bridge.dart';
-import 'package:dart_eval/src/eval/bridge/declaration/type.dart';
 import 'package:dart_eval/src/eval/compiler/expression/method_invocation.dart';
 import 'package:dart_eval/src/eval/runtime/type.dart';
 import 'package:dart_eval/src/eval/shared/types.dart';
@@ -107,7 +108,7 @@ class TypeRef {
   }
 
   factory TypeRef.fromAnnotation(CompilerContext ctx, int library, TypeAnnotation typeAnnotation) {
-    if (!(typeAnnotation is NamedType)) {
+    if (typeAnnotation is! NamedType) {
       throw CompileError('No support for generic function types yet');
     }
     final unspecifiedType = ctx.visibleTypes[library]![typeAnnotation.name.name]!;
@@ -167,7 +168,7 @@ class TypeRef {
     if (ctx.instanceDeclarationsMap[$class.file]!.containsKey($class.name) &&
         ctx.instanceDeclarationsMap[$class.file]![$class.name]!.containsKey(field)) {
       final _f = ctx.instanceDeclarationsMap[$class.file]![$class.name]![field];
-      if (!(_f is VariableDeclaration)) {
+      if (_f is! VariableDeclaration) {
         throw CompileError('Cannot query field type of F${$class.file}:${$class.name}.$field, which is not a field');
       }
       final annotation = (_f.parent as VariableDeclarationList).type;

--- a/lib/src/eval/compiler/util/graph.dart
+++ b/lib/src/eval/compiler/util/graph.dart
@@ -17,7 +17,7 @@ List<List<T>> computeStrongComponents<T>(Graph<T> graph) {
   Map<T, int> preorderNumbers = <T, int>{};
   List<T> unassigned = <T>[];
   List<T> candidates = <T>[];
-  Set<T> assigned = new Set<T>();
+  Set<T> assigned = <T>{};
 
   void recursivelySearch(T vertex) {
     // Step 1: Set the preorder number of [vertex] to [count], and increment
@@ -145,7 +145,7 @@ int _topologicalSortInternal<T>(Graph<T> graph, TopologicalSortResult<T> result,
 /// Perform a topological sorting of the vertices in [graph], returning a
 /// [TopologicalSortResult] object with the result.
 TopologicalSortResult<T> topologicalSort<T>(Graph<T> graph) {
-  TopologicalSortResult<T> result = new TopologicalSortResult();
+  TopologicalSortResult<T> result = TopologicalSortResult();
 
   for (T vertex in graph.vertices) {
     _topologicalSortInternal(graph, result, vertex);
@@ -185,14 +185,14 @@ Set<T> calculateTransitiveDependenciesOf<T>(Graph<T> graph, Set<T> vertices) {
     for (T vertex in graph.vertices) {
       if (vertices.contains(vertex)) workList.add(vertex);
       for (T neighbor in graph.neighborsOf(vertex)) {
-        (directDependencies[neighbor] ??= new Set<T>()).add(vertex);
+        (directDependencies[neighbor] ??= <T>{}).add(vertex);
         if (vertices.contains(neighbor)) workList.add(vertex);
       }
     }
   }
 
   // Collect and remove all dependencies.
-  Set<T> left = new Set<T>.of(graph.vertices);
+  Set<T> left = Set<T>.of(graph.vertices);
   Set<T> transitive = {};
   while (workList.isNotEmpty) {
     T removed = workList.removeLast();

--- a/lib/src/eval/compiler/variable.dart
+++ b/lib/src/eval/compiler/variable.dart
@@ -50,7 +50,7 @@ class Variable {
       return this;
     }
 
-    var V2 = this;
+    Variable V2 = this;
 
     if (type == EvalTypes.intType) {
       ctx.pushOp(BoxInt.make(scopeFrameOffset), BoxInt.LEN);
@@ -97,12 +97,12 @@ class Variable {
 
   Variable copyWith(
       {int? scopeFrameOffset,
-        TypeRef? type,
-        DeferredOrOffset? methodOffset,
-        ReturnType? methodReturnType,
-        String? name,
-        int? frameIndex,
-        List<TypeRef>? concreteTypes}) {
+      TypeRef? type,
+      DeferredOrOffset? methodOffset,
+      ReturnType? methodReturnType,
+      String? name,
+      int? frameIndex,
+      List<TypeRef>? concreteTypes}) {
     return Variable(scopeFrameOffset ?? this.scopeFrameOffset, type ?? this.type,
         methodOffset: methodOffset ?? this.methodOffset,
         methodReturnType: methodReturnType ?? this.methodReturnType,

--- a/lib/src/eval/runtime/declaration.dart
+++ b/lib/src/eval/runtime/declaration.dart
@@ -17,6 +17,7 @@ class EvalClass extends $InstanceImpl {
   int get $runtimeType => RuntimeTypes.typeType;
 
   @override
+  // ignore: overridden_fields
   final List<Object> values = [];
 
   final EvalClass? superclass;

--- a/lib/src/eval/runtime/runtime.dart
+++ b/lib/src/eval/runtime/runtime.dart
@@ -394,6 +394,7 @@ class Runtime {
     if (args != null) {
       this.args = args;
     }
+    // ignore: deprecated_member_use_from_same_package
     return executeNamed(_bridgeLibraryMappings[library]!, name);
   }
 

--- a/lib/src/eval/shared/stdlib/async/future.dart
+++ b/lib/src/eval/shared/stdlib/async/future.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: body_might_complete_normally_nullable
+
 import 'dart:async';
 
 import 'package:dart_eval/dart_eval.dart';
@@ -16,14 +18,22 @@ class $Completer<T> implements Completer<T>, $Instance {
 
   static const _$type = BridgeTypeRef.spec(BridgeTypeSpec('dart:async', 'Completer'), []);
 
-  static const $declaration = BridgeClassDef(BridgeClassType(_$type), constructors: {
-    '': BridgeConstructorDef(BridgeFunctionDef(returns: BridgeTypeAnnotation(_$type), params: [], namedParams: []))
-  }, methods: {
-    'complete': BridgeMethodDef(BridgeFunctionDef(
-        returns: BridgeTypeAnnotation(BridgeTypeRef.type(RuntimeTypes.voidType)),
-        params: [BridgeParameter('value', BridgeTypeAnnotation(BridgeTypeRef.type(RuntimeTypes.dynamicType)), false)],
-        namedParams: []))
-  }, getters: {}, setters: {}, fields: {}, wrap: true);
+  static const $declaration = BridgeClassDef(BridgeClassType(_$type),
+      constructors: {
+        '': BridgeConstructorDef(BridgeFunctionDef(returns: BridgeTypeAnnotation(_$type), params: [], namedParams: []))
+      },
+      methods: {
+        'complete': BridgeMethodDef(BridgeFunctionDef(
+            returns: BridgeTypeAnnotation(BridgeTypeRef.type(RuntimeTypes.voidType)),
+            params: [
+              BridgeParameter('value', BridgeTypeAnnotation(BridgeTypeRef.type(RuntimeTypes.dynamicType)), false)
+            ],
+            namedParams: []))
+      },
+      getters: {},
+      setters: {},
+      fields: {},
+      wrap: true);
 
   @override
   final Completer<T> $value;

--- a/lib/src/eval/shared/stdlib/core/iterator.dart
+++ b/lib/src/eval/shared/stdlib/core/iterator.dart
@@ -11,6 +11,7 @@ class $Iterator<E> implements Iterator, $Instance {
   @override
   Iterator<E> get $reified => $value;
 
+  // ignore: unused_field
   final $Instance _superclass;
 
   @override
@@ -20,6 +21,8 @@ class $Iterator<E> implements Iterator, $Instance {
         return $value.current as $Value;
       case 'moveNext':
         return __moveNext;
+      default:
+        return null;
     }
   }
 

--- a/lib/src/eval/shared/stdlib/core/print.dart
+++ b/lib/src/eval/shared/stdlib/core/print.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: body_might_complete_normally_nullable
+
 import 'package:dart_eval/dart_eval.dart';
 import 'package:dart_eval/dart_eval_bridge.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
    args: ^2.3.0
    analyzer: ^3.0.0
-   pedantic: ^1.11.1
    collection: ^1.15.0
    dcli: ^1.15.5
    json_annotation: ^4.4.0
@@ -19,3 +18,4 @@ dev_dependencies:
   test: ^1.17.12
   build_runner: ^2.0.0
   json_serializable: ^6.0.0
+  lints: ^1.0.0


### PR DESCRIPTION
This udpats the analysis configuration to use the Dart teams current "recommended" rule set, with some of the rules disabled as they are either stylistic or would cause alot more code chrun. 

The code changes are just "mechanical" refactors, mostly to do things like changing to us the `is!` operator and adding rule ignores for not having explicit null returns.

Unfortunately this is still a huge amoutn of code churn but hopefully is just a 1 time pass to fix up the code which will then be maintained by having CI enforce the analysis rules from here on in.

