### PR TITLE
Reset current class to null after compiling fields

### DIFF
--- a/lib/src/eval/compiler/compiler.dart
+++ b/lib/src/eval/compiler/compiler.dart
@@ -226,6 +226,7 @@ class Compiler {
             compileFieldDeclaration(-1, d, ctx, declaration);
             ctx.resetStack();
           }
+          ctx.currentClass = null;
         }
       });
     });


### PR DESCRIPTION
This was causing a bunch of tests to fail since the compiler thought it was in a class context when it wasn't. Resolves #27 