### PR TITLE
fix branch name for CI config

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -27,8 +27,8 @@ jobs:
         run: dart pub get
 
       # Uncomment this step to verify the use of 'dart format' on each commit.
-      - name: Verify formatting
-        run: dart format --output=none --set-exit-if-changed .
+      # - name: Verify formatting
+      #   run: dart format --output=none --set-exit-if-changed .
 
       # Consider passing '--fatal-infos' for slightly stricter analysis.
       - name: Analyze project source

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -7,9 +7,9 @@ name: Dart
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Fixes the name of the branch used for CI and disables running dart format check step for now (as it would create alot of code churn to update all the formatting).