### PR TITLE
Add substring method for String

### DIFF
--- a/lib/src/eval/compiler/builtins.dart
+++ b/lib/src/eval/compiler/builtins.dart
@@ -195,6 +195,10 @@ final Map<TypeRef, Map<String, KnownMethod>> knownMethods = {
         AlwaysReturnType(EvalTypes.boolType, false), [KnownMethodArg('other', EvalTypes.stringType, false, false)], {}),
     'toLowerCase': KnownMethod(AlwaysReturnType(EvalTypes.stringType, false), [], {}),
     'toUpperCase': KnownMethod(AlwaysReturnType(EvalTypes.stringType, false), [], {}),
+    'substring': KnownMethod(AlwaysReturnType(EvalTypes.stringType, false), [
+      KnownMethodArg('start', EvalTypes.intType, false, false),
+      KnownMethodArg('end', EvalTypes.intType, true, true)
+    ], {}),
     ..._knownObject
   },
   EvalTypes.iterableType: {

--- a/lib/src/eval/compiler/helpers/argument_list.dart
+++ b/lib/src/eval/compiler/helpers/argument_list.dart
@@ -131,6 +131,9 @@ Pair<List<Variable>, Map<String, Variable>> compileArgumentListWithKnownMethodAr
   Variable? $null;
 
   for (final param in params) {
+    if (param.optional && argumentList.arguments.length <= i) {
+      break;
+    }
     final arg = argumentList.arguments[i];
     if (arg is NamedExpression) {
       if (!param.optional) {

--- a/lib/src/eval/shared/stdlib/core/base.dart
+++ b/lib/src/eval/shared/stdlib/core/base.dart
@@ -144,6 +144,8 @@ class $String implements $Instance {
         return __toLowerCase;
       case 'toUpperCase':
         return __toUpperCase;
+      case 'substring':
+        return __substring;
     }
 
     return _superclass.$getProperty(runtime, identifier);
@@ -172,6 +174,15 @@ class $String implements $Instance {
 
   static $Value? _toUpperCase(final Runtime runtime, final $Value? target, final List<$Value?> args) {
     return $String((target!.$value as String).toUpperCase());
+  }
+
+  static const $Function __substring = $Function(_substring);
+
+  static $Value? _substring(final Runtime runtime, final $Value? target, final List<$Value?> args) {
+    target as $String;
+    final start = args[0] as $int;
+    final end = args[1] as $int;
+    return $String(target.$value.substring(start.$value, end.$value));
   }
 
   @override

--- a/lib/src/eval/shared/stdlib/core/base.dart
+++ b/lib/src/eval/shared/stdlib/core/base.dart
@@ -181,8 +181,8 @@ class $String implements $Instance {
   static $Value? _substring(final Runtime runtime, final $Value? target, final List<$Value?> args) {
     target as $String;
     final start = args[0] as $int;
-    final end = args[1] as $int;
-    return $String(target.$value.substring(start.$value, end.$value));
+    final end = args.length > 1 ? args[1] as $int : null;
+    return $String(target.$value.substring(start.$value, end?.$value));
   }
 
   @override

--- a/test/dart_eval_test.dart
+++ b/test/dart_eval_test.dart
@@ -540,6 +540,22 @@ void main() {
         exec.executeLib('package:example/main.dart', 'main');
       }, prints('Flu\n'));
     });
+    test('String substring method works with only 1 parameter', () {
+      final exec = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            int main() {
+              String cat = "Fluffy";
+              String sub = cat.substring(3);
+              print(sub);
+            }
+          ''',
+        }
+      });
+      expect(() {
+        exec.executeLib('package:example/main.dart', 'main');
+      }, prints('ffy\n'));
+    });
   });
 
   group('Bridge tests', () {

--- a/test/dart_eval_test.dart
+++ b/test/dart_eval_test.dart
@@ -495,6 +495,51 @@ void main() {
         runtime.executeLib('package:example/main.dart', 'main', [56890]);
       }, prints('56890\n'));
     });
+
+    test('String has length getter', () {
+      final exec = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            int main() {
+              String cat = "Fluffy";
+              return cat.length;
+            }
+          ''',
+        }
+      });
+      expect(exec.executeLib('package:example/main.dart', 'main'), 6);
+    });
+
+    test('String has isEmpty getter', () {
+      final exec = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            int main() {
+              String cat = "Fluffy";
+              if (cat.isNotEmpty) return 1;
+            }
+          ''',
+        }
+      });
+      expect(exec.executeLib('package:example/main.dart', 'main'), 1);
+    });
+
+    test('String has substring method', () {
+      final exec = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            int main() {
+              String cat = "Fluffy";
+              String sub = cat.substring(0,3);
+              print(sub);
+            }
+          ''',
+        }
+      });
+      expect(() {
+        exec.executeLib('package:example/main.dart', 'main');
+      }, prints('Flu\n'));
+    });
   });
 
   group('Bridge tests', () {


### PR DESCRIPTION
This adds an implementation for `String`'s [`substring()` method](https://api.dart.dev/stable/2.17.0/dart-core/String/substring.html) along with some tests for it and a test for the existing `length` getter.

Fixes: #26 