### PR TITLE
README.md: Add a call to setup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ void main() {
       .asByteData();
   
   final runtime = Runtime(bytecode);
+  runtime.setup();
   print(runtime.executeLib('package:my_package/main.dart', 'main')); // -> 499500
 }
 ```


### PR DESCRIPTION
Running the `Runtime` example doesn't work, because the `setup()` needs to be called.