### PR TITLE
try to fix compile error in DeferredOrOffset

### DIFF
--- a/lib/src/eval/compiler/reference.dart
+++ b/lib/src/eval/compiler/reference.dart
@@ -298,7 +298,7 @@ class IdentifierReference implements Reference {
 
       if (ctx.topLevelDeclarationPositions[_decl.sourceLib]?.containsKey('$name.') ?? false) {
         offset =
-            DeferredOrOffset(file: _decl.sourceLib, offset: ctx.topLevelDeclarationPositions[ctx.library]!['$name.'], name: '$name.');
+            DeferredOrOffset(file: _decl.sourceLib, offset: ctx.topLevelDeclarationPositions[ctx.library]!['$name.']);
       } else {
         offset = DeferredOrOffset(file: _decl.sourceLib, name: '$name.');
       }

--- a/lib/src/eval/compiler/reference.dart
+++ b/lib/src/eval/compiler/reference.dart
@@ -298,7 +298,7 @@ class IdentifierReference implements Reference {
 
       if (ctx.topLevelDeclarationPositions[_decl.sourceLib]?.containsKey('$name.') ?? false) {
         offset =
-            DeferredOrOffset(file: _decl.sourceLib, offset: ctx.topLevelDeclarationPositions[ctx.library]!['$name.']);
+            DeferredOrOffset(file: _decl.sourceLib, offset: ctx.topLevelDeclarationPositions[_decl.sourceLib]!['$name.']);
       } else {
         offset = DeferredOrOffset(file: _decl.sourceLib, name: '$name.');
       }
@@ -382,7 +382,7 @@ class IdentifierReference implements Reference {
 
       if (ctx.topLevelDeclarationPositions[_decl.sourceLib]?.containsKey('$name.') ?? false) {
         offset =
-            DeferredOrOffset(file: _decl.sourceLib, offset: ctx.topLevelDeclarationPositions[ctx.library]!['$name.']);
+            DeferredOrOffset(file: _decl.sourceLib, offset: ctx.topLevelDeclarationPositions[_decl.sourceLib]!['$name.']);
       } else {
         offset = DeferredOrOffset(file: _decl.sourceLib, name: '$name.');
       }

--- a/lib/src/eval/compiler/reference.dart
+++ b/lib/src/eval/compiler/reference.dart
@@ -298,7 +298,7 @@ class IdentifierReference implements Reference {
 
       if (ctx.topLevelDeclarationPositions[_decl.sourceLib]?.containsKey('$name.') ?? false) {
         offset =
-            DeferredOrOffset(file: _decl.sourceLib, offset: ctx.topLevelDeclarationPositions[ctx.library]!['$name.']);
+            DeferredOrOffset(file: _decl.sourceLib, offset: ctx.topLevelDeclarationPositions[ctx.library]!['$name.'], name: '$name.');
       } else {
         offset = DeferredOrOffset(file: _decl.sourceLib, name: '$name.');
       }


### PR DESCRIPTION
Problem Description:

I have created a demo project [flutter_eval_gallery](https://github.com/maxiee/flutter_eval_gallery) to experience flutter_eval. The project consists of two nested subprojects, the internal project is template which will be compiled into EVC bytecode by the dart_eval compiler. The external project in the root directory is the execution project. At runtime, the external project loads the template bytecode as assets and dynamically executes the template through the dart_eval runtime implementation.

The problem I'm having is that compiling the template with dart_eval compile is reporting errors.

Specifically, I have two computers, one running Windows 11 and one running macOS 11.6.8. The computer runs successfully on Windows, but the compilation of the template fails on the macOS computer.

Environment for both computers:

* Windows: Flutter 3.7.3, Dart 2.19.2, dart_eval 0.5.6, flutter_eval 0.5.4
* macOS: Flutter 3.7.3, Dart 2.19.2, dart_eval 0.5.6, flutter_eval 0.5.4

The above environment versions are the same for both computers. I'm trying to figure out why the macOS device fails to compile while the Windows device does.

macOS error log:

```
# flutter_eval_gallery % cd template
# template % dart_eval compile -o a.evc
Loading files...
Found binding file: .dart_eval/bindings/flutter_eval.json
Compiling package template...
Unhandled exception:
Null check operator used on a null value
#0      OffsetTracker.apply.<anonymous closure> (package:dart_eval/src/eval/compiler/offset_tracker.dart:19:95)
#1      _LinkedHashMapMixin.forEach (dart:collection-patch/compact_hash.dart:625:13)
#2      OffsetTracker.apply (package:dart_eval/src/eval/compiler/offset_tracker.dart:16:22)
#3      Compiler.compileSources (package:dart_eval/src/eval/compiler/compiler.dart:380:27)
#4      Compiler.compile (package:dart_eval/src/eval/compiler/compiler.dart:131:12)
#5      main (file:///Users/maxiee/.pub-cache/hosted/pub.flutter-io.cn/dart_eval-0.5.6/bin/dart_eval.dart:125:36)
#6      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:295:33)
#7      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:192:26)
```

The apply method of OffsetTracker throws an exception.  The [source](https://github.com/ethanblake4/dart_eval/blob/ce0b32c4f9afd27201e88bde5d1c61c33b5eeb0f/lib/src/eval/compiler/offset_tracker.dart#L19) is as below:

```dart
List<EvcOp> apply(List<EvcOp> source) {
  _deferredOffsets.forEach((pos, offset) {
    final op = source[pos];
    if (op is Call) {
      final resolvedOffset = context.topLevelDeclarationPositions[offset.file!]![offset.name!]!;
      final newOp = Call.make(resolvedOffset);
      source[pos] = newOp;
    }
  });
  return source;
}
```

Where: `offset.name` is null, so `offset.name!` reports an error with the `Null check operator used on a null value`.

When I think about the cause of the problem, it happened when DeferredOrOffset was constructed, and the name was passed in as null during construction.

I found that there are many places where DeferredOrOffset is constructed, and there are many scenarios where it can be used, but the one that caused the macOS compilation to fail was one of them. With some debugging, I was able to pinpoint the location of the DeferredOrOffset construct that was causing the failure: the getValue() method of the IdentifierReference, located at [L301](https://github.com/ethanblake4/dart_eval/blob/a597622c23aa2cbb0f6846ff53b377519aa11fa0/lib/src/eval/compiler/reference.dart#L301):

```dart
if (decl is! FunctionDeclaration && decl is! ConstructorDeclaration) {
  decl as ClassDeclaration;

  final returnType = TypeRef.lookupClassDeclaration(ctx, _decl.sourceLib, decl);
  final DeferredOrOffset offset;

  if (ctx.topLevelDeclarationPositions[_decl.sourceLib]?.containsKey('$name.') ?? false) {
    offset =
        DeferredOrOffset(file: _decl.sourceLib, offset: ctx.topLevelDeclarationPositions[ctx.library]!['$name.']);
  } else {
    offset = DeferredOrOffset(file: _decl.sourceLib, name: '$name.');
  }

  return Variable(-1, EvalTypes.typeType,
      concreteTypes: [returnType], methodOffset: offset, methodReturnType: AlwaysReturnType(returnType, false));
}
```

In actual debugging, the name that causes the compile error to be reported as 'SubPage.' I found that it goes to the else branch on Windows devices and the if branch on macOS devices. This is an observed phenomenon, but the reason behind it is not well understood.

When the if branch is entered on macOS devices, the name parameter is not passed to the DeferredOrOffset constructor, resulting in an error when applying the OffsetTracker in the previous analysis.

I found that the name parameter is fully available in the if branch, so I tried to add it to the constructor. After adding it, macOS compiles and runs normally, and Windows still runs successfully.

Here's my fix for this PR, and the thinking behind it.

Since I do not yet fully understand how the project works and am still extrapolating more based on phenomena, my fix may cause potential problems. Please also discuss and analyze it together.

I tried to think further about the cause, and it looks like the `ctx.topLevelDeclarationPositions` generation process is different for the two computers. I have made an attempt.

When the `getValue()` of `IdentifierReference` is executed to 'SubPage.', the value of `ctx.topLevelDeclarationPositions` is printed, and the corresponding code is as follows.

```dart
if (decl is! FunctionDeclaration && decl is! ConstructorDeclaration) {
  decl as ClassDeclaration;

  final returnType = TypeRef.lookupClassDeclaration(ctx, _decl.sourceLib, decl);
  final DeferredOrOffset offset;

  // added by me
  if (name == "SubPage") {
    print(ctx.topLevelDeclarationPositions);
  }

  if (ctx.topLevelDeclarationPositions[_decl.sourceLib]?.containsKey('$name.') ?? false) {
    offset =
        DeferredOrOffset(file: _decl.sourceLib, offset: ctx.topLevelDeclarationPositions[ctx.library]!['$name.']);
  } else {
    offset = DeferredOrOffset(file: _decl.sourceLib, name: '$name.');
  }

  return Variable(-1, EvalTypes.typeType,
      concreteTypes: [returnType], methodOffset: offset, methodReturnType: AlwaysReturnType(returnType, false));
}
```

Windows:

```
{0: {}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}, 8: {}, 9: {}, 10: {}, 11: {Colors._: 34184}, 12: {}, 13: {}, 14: {}, 15: {}, 16: {}, 17: {}, 18: {}, 19: {}, 20: {}, 21: {}, 22: {}, 23: {}, 24: {}, 25: {}, 26: {}, 27: {}, 28: {}, 29: {}, 30: {Curves._: 34188}, 31: {}, 32: {}, 33: {}, 34: {}, 35: {}, 36: {}, 37: {}, 38: {}, 39: {}, 40: {}, 41: {}, 42: {}, 43: {}}
```

macOS:

```
{0: {}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}, 8: {}, 9: {}, 10: {}, 11: {Colors._: 34184}, 12: {}, 13: {}, 14: {}, 15: {}, 16: {}, 17: {}, 18: {}, 19: {}, 20: {}, 21: {}, 22: {}, 23: {}, 24: {}, 25: {}, 26: {}, 27: {}, 28: {}, 29: {}, 30: {Curves._: 34188}, 31: {}, 32: {}, 33: {}, 34: {}, 35: {}, 36: {}, 37: {}, 38: {}, 39: {}, 40: {}, 41: {}, 42: {}, 43: {SubPage.: 34236}, 44: {StatelessWidgetPage.: 34286}, 45: {StatefulWidgetPage.: 34297, _StatefulWidgetPageState.: 34366}, 46: {ViewModel.: 34386, ChangeNotifierPage.: 34400, _ChangeNotifierPageState.: 34545}, 47: {}}
```

They are indeed not quite the same.