### PR TITLE
add containsKey method to Map object

### DIFF
--- a/lib/src/eval/shared/stdlib/core/map.dart
+++ b/lib/src/eval/shared/stdlib/core/map.dart
@@ -51,6 +51,16 @@ class $Map<K, V> implements Map<K, V>, $Instance {
                 returns:
                     BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.voidType))),
             isStatic: false),
+        'containsKey': BridgeMethodDef(
+          BridgeFunctionDef(params: [
+            BridgeParameter(
+                'key',
+                BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.object),
+                    nullable: true),
+                false),
+          ], returns: BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.bool))),
+          isStatic: false,
+        ),
       },
       getters: {
         'entries': BridgeMethodDef(BridgeFunctionDef(
@@ -78,6 +88,8 @@ class $Map<K, V> implements Map<K, V>, $Instance {
         return __cast;
       case 'length':
         return $int($value.length);
+      case 'containsKey':
+        return __containsKey;
       case 'entries':
         return $Iterable.wrap(entries.map((e) => $MapEntry.wrap(e)));
     }
@@ -122,6 +134,18 @@ class $Map<K, V> implements Map<K, V>, $Instance {
 
   static $Value? _cast(Runtime runtime, $Value? target, List<$Value?> args) {
     return target;
+  }
+
+  static const $Function __containsKey = $Function(_containsKey);
+
+  static $Value? _containsKey(
+      Runtime runtime, $Value? target, List<$Value?> args) {
+    final mapObject = target!.$reified as Map;
+    // remove "$" and double quotation sign(")
+    final keyToFind =
+        args[0].toString().replaceAll('\$', '').replaceAll('"', '');
+    final containsKey = mapObject.containsKey(keyToFind);
+    return $bool(containsKey);
   }
 
   @override

--- a/lib/src/eval/shared/stdlib/core/map.dart
+++ b/lib/src/eval/shared/stdlib/core/map.dart
@@ -140,12 +140,7 @@ class $Map<K, V> implements Map<K, V>, $Instance {
 
   static $Value? _containsKey(
       Runtime runtime, $Value? target, List<$Value?> args) {
-    final mapObject = target!.$reified as Map;
-    // remove "$" and double quotation sign(")
-    final keyToFind =
-        args[0].toString().replaceAll('\$', '').replaceAll('"', '');
-    final containsKey = mapObject.containsKey(keyToFind);
-    return $bool(containsKey);
+    return $bool((target!.$value as Map).containsKey(args[0]));
   }
 
   @override

--- a/test/collection_test.dart
+++ b/test/collection_test.dart
@@ -134,4 +134,27 @@ void main() {
           $String('012103223312'));
     });
   });
+
+  group('Map tests', () {
+    late Compiler compiler;
+
+    setUp(() {
+      compiler = Compiler();
+    });
+
+    test('Map.containsKey()', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'eval_test': {
+          'main.dart': '''
+            bool main() {
+              final testMap = {'name': 'Jon', 'id':0};
+              return testMap.containsKey('id');
+            }
+          '''
+        }
+      });
+
+      expect(runtime.executeLib('package:eval_test/main.dart', 'main'), true);
+    });
+  });
 }


### PR DESCRIPTION
I followed the convention of the codebase and added `containsKey` method.

The method was implemented as `containsKey(Object? key) → bool`

Sample code to test:
```dart
void main() {
  final program = '''
  final testMap = {'name': 'Jon', 'id':0};
  print(testMap.containsKey('id'));
  ''';
  print(eval(program, function: 'main'));
}
```

closes #147 