### PR TITLE
Normalize Paths in Filesystem Permissions to Fix Directory-Dependent Bugs

### DIFF
--- a/lib/src/eval/runtime/runtime.dart
+++ b/lib/src/eval/runtime/runtime.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:path/path.dart' as p;
+
 import 'package:dart_eval/dart_eval.dart';
 import 'package:dart_eval/dart_eval_bridge.dart';
 import 'package:dart_eval/dart_eval_security.dart';
@@ -310,6 +312,11 @@ class Runtime {
 
   /// Check if a permission is granted.
   bool checkPermission(String domain, [Object? data]) {
+    if (domain == 'filesystem:read' || domain == 'filesystem:write') {
+      if (data is String) {
+        data = p.normalize(p.absolute(data));
+      }
+    }
     return _permissions[domain]?.any((element) => element.match(data)) ?? false;
   }
 

--- a/lib/src/eval/runtime/security/permissions/filesystem.dart
+++ b/lib/src/eval/runtime/security/permissions/filesystem.dart
@@ -1,3 +1,4 @@
+import 'package:path/path.dart' as p;
 import 'package:dart_eval/dart_eval_security.dart';
 
 /// A permission that allows access to read and write a file system resource.
@@ -14,13 +15,15 @@ class FilesystemPermission implements Permission {
   /// Create a new filesystem permission that matches any file in a directory
   /// or one of its subdirectories.
   factory FilesystemPermission.directory(String dir) {
-    final escaped = dir.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
+    final normalized = p.normalize(p.absolute(dir));
+    final escaped = normalized.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
     return FilesystemPermission(RegExp('^$escaped.*'));
   }
 
   /// Create a new filesystem permission that matches a specific file.
   factory FilesystemPermission.file(String file) {
-    final escaped = file.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
+    final normalized = p.normalize(p.absolute(file));
+    final escaped = normalized.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
     return FilesystemPermission(RegExp('^$escaped\$'));
   }
 
@@ -59,13 +62,15 @@ class FilesystemReadPermission extends FilesystemPermission {
   /// Create a new filesystem permission that matches any file in a directory
   /// or one of its subdirectories.
   factory FilesystemReadPermission.directory(String dir) {
-    final escaped = dir.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
+    final normalized = p.normalize(p.absolute(dir));
+    final escaped = normalized.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
     return FilesystemReadPermission(RegExp('^$escaped.*'));
   }
 
   /// Create a new filesystem permission that matches a specific file.
   factory FilesystemReadPermission.file(String file) {
-    final escaped = file.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
+    final normalized = p.normalize(p.absolute(file));
+    final escaped = normalized.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
     return FilesystemReadPermission(RegExp('^$escaped\$'));
   }
 
@@ -104,13 +109,15 @@ class FilesystemWritePermission extends FilesystemPermission {
   /// Create a new filesystem permission that matches any file in a directory
   /// or one of its subdirectories.
   factory FilesystemWritePermission.directory(String dir) {
-    final escaped = dir.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
+    final normalized = p.normalize(p.absolute(dir));
+    final escaped = normalized.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
     return FilesystemWritePermission(RegExp('^$escaped.*'));
   }
 
   /// Create a new filesystem permission that matches a specific file.
   factory FilesystemWritePermission.file(String file) {
-    final escaped = file.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
+    final normalized = p.normalize(p.absolute(file));
+    final escaped = normalized.replaceAll(r'\', r'\\').replaceAll(r'/', r'\/');
     return FilesystemWritePermission(RegExp('^$escaped\$'));
   }
 


### PR DESCRIPTION
Previously, filesystem permission checks could fail when the current working directory changed, because relative paths were not consistently resolved. By ensuring all permission checks and grants use normalized, absolute paths, permissions now work reliably regardless of the current directory. This change eliminates bugs caused by path resolution issues and makes permission matching robust across all environments.