### PR TITLE
fix: flutter 3.29.x Parsing error(s): [(321..325): Doc directive 'nodoc' is unknown.

### DIFF
--- a/lib/src/eval/cli/compile.dart
+++ b/lib/src/eval/cli/compile.dart
@@ -95,6 +95,11 @@ void cliCompile(String outputName) {
   }
   var skips = '';
   for (final package in packageConfig.packages) {
+    if (package.name == 'sky_engine') {
+      skips += 'Skipped SDK package sky_engine.\n';
+      continue;
+    }
+
     if (bridgedPackages.contains(package.name)) {
       skips += 'Skipped package ${package.name} because it is bridged.\n';
       continue;


### PR DESCRIPTION
##  Skip `sky_engine` During Package Parsing in CLI Compile


![error](https://github.com/user-attachments/assets/195fb0dc-6038-4b7f-800e-77dd920025f6)



### Summary

This PR updates the Dart Eval CLI compiler to **skip the `sky_engine` package** during the package parsing phase. `sky_engine` is an SDK-internal package that does not need to be parsed or compiled, and including it leads to unnecessary processing or potential path resolution errors.

### Changes Made

- Added a condition to ignore `sky_engine` when iterating over packages in `package_config.json`.
- Enhanced the skip message log for clarity.

### Code Highlight

```dart
for (final package in packageConfig.packages) {
  if (package.name == 'sky_engine') {
    skips += 'Skipped SDK package sky_engine.\n';
    continue;
  }

  if (bridgedPackages.contains(package.name)) {
    skips += 'Skipped package ${package.name} because it is bridged.\n';
    continue;
  }

  if (packageName == package.name) {
    continue;
  }

  stdout.write('${package.name} ');

  String filepath;
  try {
    filepath = package.packageUriRoot.toFilePath();
  } catch (e) {
    filepath = package.packageUriRoot.toString();
  }

  final pkgDir = Directory(filepath);
  addFiles(package.name, pkgDir, pkgDir.path);
}
```

### Why I skipped sky engine ?
The `sky_engine` package is part of the Dart SDK internals and is marked with a  `@nodoc` annotation, which causes dart_eval to throw the `nodoc` exception which is quite confusing to a user.

To checkout the `nodoc`  annotated file check it out  on any 3.29 distribution on `package:sky_engine/concurrent/concurrent.dart`


### Did I test my patch ?
Yes tested on both Linux Desktop and Android emulator and everything works as expected on 3.29.3

