### PR TITLE
Enhance Filesystem Permission System with Robust Path Handling and Symlink Support

### DIFF
--- a/lib/src/eval/utils/path_helper.dart
+++ b/lib/src/eval/utils/path_helper.dart
@@ -1,0 +1,160 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+/// Check if a given path is allowed by this permission
+bool isPathAllowed(String targetPath, String allowedPath) {
+  // Empty allowedPath means allow everything (any permission)
+  if (allowedPath.isEmpty) return true;
+
+  // Normalize both paths using the same resolution method
+  String normalizedTarget = normalizePath(targetPath);
+  String normalizedAllowed = allowedPath;
+
+  // Both paths should now be consistently resolved (with symlinks resolved when possible)
+
+  // Ensure both paths end consistently for directory checks
+  // If allowed path is a directory, ensure it ends with separator for proper containment check
+  if (normalizedAllowed.isNotEmpty &&
+      !normalizedAllowed.endsWith(p.separator)) {
+    // Check if it's a directory or if we should treat it as one
+    bool isDirectory = false;
+    try {
+      isDirectory = Directory(normalizedAllowed).existsSync();
+    } catch (e) {
+      // Ignore exceptions and fall through to heuristic check
+    }
+
+    // If directory doesn't exist, use heuristic: assume it's a directory if basename has no extension
+    if (!isDirectory && !p.basename(normalizedAllowed).contains('.')) {
+      isDirectory = true;
+    }
+
+    if (isDirectory) {
+      normalizedAllowed = normalizedAllowed + p.separator;
+    }
+  }
+
+  // Check if target is the same as or within allowed path
+  if (normalizedTarget ==
+      normalizedAllowed.replaceAll(RegExp(r'[/\\]+$'), '')) {
+    return true; // Exact match
+  }
+
+  // Check if target is within allowed directory
+  if (normalizedAllowed.endsWith(p.separator)) {
+    return normalizedTarget.startsWith(normalizedAllowed);
+  }
+
+  // For file permissions, check exact match
+  return normalizedTarget == normalizedAllowed;
+}
+
+/// Normalize a path by resolving symlinks and ensuring consistent separators
+String normalizePath(String path) {
+  if (path.isEmpty) return '';
+
+  // Convert to absolute path and normalize
+  String absolutePath = p.isAbsolute(path) ? path : p.absolute(path);
+
+  // Normalize to resolve .. and . components and remove redundant separators
+  String normalized = p.normalize(absolutePath);
+
+  // Try to resolve symlinks by walking up the directory tree
+  String resolved = resolvePathRecursively(normalized);
+
+  return resolved;
+}
+
+/// Recursively resolve symlinks by walking up the directory hierarchy
+String resolvePathRecursively(String path) {
+  try {
+    // Try to resolve the full path directly first
+    if (File(path).existsSync()) {
+      return File(path).resolveSymbolicLinksSync();
+    } else if (Directory(path).existsSync()) {
+      return Directory(path).resolveSymbolicLinksSync();
+    }
+
+    // If the path doesn't exist, find the deepest existing parent and resolve it
+    String current = path;
+    List<String> nonExistentParts = [];
+
+    while (current != p.dirname(current)) {
+      // While not at root
+      // Add the current basename to non-existent parts FIRST
+      nonExistentParts.add(p.basename(current));
+
+      String parent = p.dirname(current);
+
+      if (Directory(parent).existsSync()) {
+        // Found an existing parent, resolve it and rebuild the path
+        String resolvedParent = Directory(parent).resolveSymbolicLinksSync();
+
+        // Rebuild the path with resolved parent + non-existent parts (in reverse order)
+        String result = resolvedParent;
+        for (String part in nonExistentParts.reversed) {
+          result = p.join(result, part);
+        }
+
+        return result;
+      }
+
+      // Move up to parent
+      current = parent;
+    }
+
+    // If we reach here, no parent could be resolved
+    return path;
+  } catch (e) {
+    // If any resolution fails, return the original path
+    return path;
+  }
+}
+
+/// An [IOOverrides] implementation that safely overrides the current working directory
+/// for file system operations at runtime.
+///
+/// This class is useful when you need to execute code with a different current directory,
+/// especially on platforms like Android and iOS where directly setting [Directory.current]
+/// is not recommended or may cause issues.
+///
+/// All file, directory, and link operations performed through this override will be
+/// resolved relative to the specified [currentDir], ensuring isolation and safety.
+///
+/// Example usage:
+/// ```dart
+/// IOOverrides.runWithOverrides(
+///   () {
+///     // File operations here will use the overridden current directory.
+///     // like: runtime.executeLib('package:example/main.dart', 'main');
+///   },
+///   CurrentDirIOOverrides('/my/custom/path'),
+/// );
+/// ```
+class CurrentDirIOOverrides extends IOOverrides {
+  final String currentDir;
+  CurrentDirIOOverrides(this.currentDir);
+
+  @override
+  File createFile(String path) =>
+      super.createFile(p.normalize(p.join(currentDir, path)));
+
+  @override
+  Directory createDirectory(String path) =>
+      super.createDirectory(p.normalize(p.join(currentDir, path)));
+
+  @override
+  Directory getCurrentDirectory() => Directory(currentDir);
+
+  @override
+  Link createLink(String path) =>
+      super.createLink(p.normalize(p.join(currentDir, path)));
+
+  @override
+  Future<FileStat> stat(String path) async =>
+      await FileStat.stat(p.normalize(p.join(currentDir, path)));
+
+  @override
+  FileStat statSync(String path) =>
+      FileStat.statSync(p.normalize(p.join(currentDir, path)));
+}

--- a/test/filesystem_permission_test.dart
+++ b/test/filesystem_permission_test.dart
@@ -1,0 +1,236 @@
+import 'dart:io';
+import 'package:dart_eval/src/eval/utils/path_helper.dart';
+import 'package:test/test.dart';
+import 'package:dart_eval/dart_eval.dart';
+import 'package:dart_eval/dart_eval_security.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('FilesystemPermission Tests', () {
+    late Directory tempDir;
+    late String tempDirPath;
+    late Compiler compiler;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('fs_permission_test');
+      tempDirPath = tempDir.path;
+      compiler = Compiler();
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('should allow access to exact file', () {
+      final testFile = File(p.join(tempDirPath, 'test.txt'));
+      final permission = FilesystemPermission.file(testFile.path);
+
+      expect(permission.match(testFile.path), isTrue);
+    });
+
+    test('should allow access to files within directory', () {
+      final permission = FilesystemPermission.directory(tempDirPath);
+      final testFile = p.join(tempDirPath, 'subdir', 'test.txt');
+
+      expect(permission.match(testFile), isTrue);
+    });
+
+    test('should deny access to files outside allowed directory', () {
+      final subDir = Directory(p.join(tempDirPath, 'allowed'));
+      final permission = FilesystemPermission.directory(subDir.path);
+      final deniedFile = p.join(tempDirPath, 'denied.txt');
+
+      expect(permission.match(deniedFile), isFalse);
+    });
+
+    test('should handle relative paths by converting to absolute', () {
+      // FilesystemPermission resolves paths based on the actual current working directory,
+      // not the dart_eval runtime's currentDir
+      final permission =
+          FilesystemPermission.file(p.join(tempDirPath, 'test.txt'));
+      final absolutePath = p.join(tempDirPath, 'test.txt');
+
+      // The permission was created with absolute path, so it should match the absolute path
+      expect(permission.match(absolutePath), isTrue);
+
+      // For relative path matching, the permission system uses the actual current working directory
+      // This test demonstrates that permissions work with absolute paths
+      final relativePermission = FilesystemPermission.directory(tempDirPath);
+      expect(relativePermission.match(absolutePath), isTrue);
+    });
+
+    test('should prevent path traversal attacks', () {
+      final subDir = Directory(p.join(tempDirPath, 'allowed'));
+      final permission = FilesystemPermission.directory(subDir.path);
+
+      // Try to escape using ../
+      final escapeAttempt = p.join(subDir.path, '..', 'secret.txt');
+
+      expect(permission.match(escapeAttempt), isFalse);
+      expect(permission.match('../secret.txt'), isFalse);
+    });
+
+    test('FilesystemReadPermission should only allow read operations', () {
+      final permission = FilesystemReadPermission.directory(tempDirPath);
+      final testFile = p.join(tempDirPath, 'test.txt');
+
+      expect(permission.domains, equals(['filesystem:read']));
+      expect(permission.match(testFile), isTrue);
+    });
+
+    test('FilesystemWritePermission should only allow write operations', () {
+      final permission = FilesystemWritePermission.directory(tempDirPath);
+      final testFile = p.join(tempDirPath, 'test.txt');
+
+      expect(permission.domains, equals(['filesystem:write']));
+      expect(permission.match(testFile), isTrue);
+    });
+
+    test('FilesystemPermission.any should allow access to everything', () {
+      final permission = FilesystemPermission.any;
+
+      expect(permission.match('/any/path/anywhere'), isTrue);
+      expect(permission.match('/etc/passwd'), isTrue);
+      expect(permission.match('relative/path'), isTrue);
+    });
+
+    test('should handle non-existent paths', () {
+      final nonExistentDir = p.join(tempDirPath, 'nonexistent');
+      final permission = FilesystemPermission.directory(nonExistentDir);
+      final testFile = p.join(nonExistentDir, 'test.txt');
+
+      expect(permission.match(testFile), isTrue);
+    });
+
+    test('permissions should be equal when paths are the same', () {
+      final perm1 = FilesystemPermission.directory(tempDirPath);
+      final perm2 = FilesystemPermission.directory(tempDirPath);
+
+      expect(perm1, equals(perm2));
+      expect(perm1.hashCode, equals(perm2.hashCode));
+    });
+
+    test('permissions should not be equal when paths differ', () {
+      final perm1 = FilesystemPermission.directory(tempDirPath);
+      final perm2 = FilesystemPermission.directory('/different/path');
+
+      expect(perm1, isNot(equals(perm2)));
+    });
+
+    test('should allow file read/write/delete using IOOverrides for currentDir',
+        () async {
+      final runtime = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            import 'dart:io';
+
+            Future<String> main() async {
+              try {
+                final file = File('test_permission.txt');
+                await file.writeAsString('Testing permissions');
+                final content = await file.readAsString();
+                await file.delete();
+                return content;
+              } catch (e) {
+                return 'error: \$e';
+              }
+            }
+          '''
+        }
+      });
+
+      runtime.grant(FilesystemPermission.directory(tempDirPath));
+
+      final result = await IOOverrides.runWithIOOverrides<Future<dynamic>>(
+        () async =>
+            await runtime.executeLib('package:example/main.dart', 'main'),
+        CurrentDirIOOverrides(tempDirPath),
+      );
+
+      expect(result.$value, 'Testing permissions');
+    });
+
+    test(
+        'should allow file operations in subdirectory using relative path when currentDir is set and permission is granted for parent directory',
+        () async {
+      final runtime = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+        import 'dart:io';
+
+        Future<String> main() async {
+          final file = File('subdir/relative_file.txt');
+          await file.writeAsString('Relative path with currentDir');
+          final content = await file.readAsString();
+          await file.delete();
+          return content;
+        }
+        '''
+        }
+      });
+
+      // Create subdirectory in tempDir
+      final subDir = Directory(p.join(tempDirPath, 'subdir'));
+      await subDir.create();
+
+      // Grant permission for the entire temp directory
+      runtime.grant(FilesystemPermission.directory(tempDirPath));
+
+      // Set runtime's currentDir to the temp directory
+      final result = await IOOverrides.runWithIOOverrides<Future<dynamic>>(
+        () async =>
+            await runtime.executeLib('package:example/main.dart', 'main'),
+        CurrentDirIOOverrides(tempDirPath),
+      );
+
+      expect(result.$value, 'Relative path with currentDir');
+
+      // Clean up
+      await subDir.delete();
+    });
+
+    test('resolves relative file paths using currentDir with permissions',
+        () async {
+      final runtime = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            import 'dart:io';
+
+            Future<String> main() async {
+              // File created with relative path - will be resolved using runtime.currentDir
+              final file = File('resolved_file.txt');
+              await file.writeAsString('File resolved through currentDir');
+
+              // Check the absolute path of the created file
+              final absolutePath = file.absolute.path;
+
+              final content = await file.readAsString();
+              await file.delete();
+
+              return '\$content||\$absolutePath';
+            }
+          '''
+        }
+      });
+
+      // Grant permission for the temp directory where files will actually be created
+      runtime.grant(FilesystemPermission.directory(tempDirPath));
+
+      final result = await IOOverrides.runWithIOOverrides<Future<dynamic>>(
+        () async =>
+            await runtime.executeLib('package:example/main.dart', 'main'),
+        CurrentDirIOOverrides(tempDirPath),
+      );
+
+      final parts = (result.$value as String).split('||');
+
+      expect(parts[0], 'File resolved through currentDir');
+      expect(
+          parts[1],
+          contains(
+              tempDirPath)); // The absolute path should contain our temp directory
+    });
+  });
+}


### PR DESCRIPTION
Instead of using regex which can fail in cases involving symlinks (for example, on Android, `/data/data` and `/data/user/0` refer to the same path), or when using relative paths like `./` or `../`, this PR uses a more reliable approach. Regex checks also break when the current directory changes or when absolute paths are used. This PR addresses all of these issues by replacing the regex logic with a more robust solution.
