### PR TITLE
Add error handling for future in Await's _suspend method

### DIFF
--- a/lib/src/eval/runtime/ops/bridge.dart
+++ b/lib/src/eval/runtime/ops/bridge.dart
@@ -162,14 +162,14 @@ class Await implements EvcOp {
 
   void _suspend(Runtime runtime, Continuation continuation, $Future future,
       Completer completer) async {
-    final result = await future.$value;
-    runtime.returnValue = result;
-    runtime.frameOffset = continuation.frameOffset;
-    runtime.frame = continuation.frame;
-    runtime.stack.add(continuation.frame);
-    runtime.scopeNameStack.add('<asynchronous gap>');
-
     try {
+      final result = await future.$value;
+      runtime.returnValue = result;
+      runtime.frameOffset = continuation.frameOffset;
+      runtime.frame = continuation.frame;
+      runtime.stack.add(continuation.frame);
+      runtime.scopeNameStack.add('<asynchronous gap>');
+
       runtime.bridgeCall(continuation.programOffset);
     } catch (e) {
       // temporary fix: this isn't correct, we need to reenter the eval loop


### PR DESCRIPTION
This PR fixes an issue where errors thrown from bridged Future functions were not correctly propagated to the runtime. Previously, if a bridged function (such as a Dart closure returning a Future) threw an error, the runtime would remain in an awaiting state indefinitely, making it impossible to catch or handle the error in user code.

With this fix, exceptions thrown from bridge futures are now properly surfaced and can be caught as expected.