### PR TITLE
compiler: register source-code enum values

### DIFF
--- a/lib/src/eval/compiler/compiler.dart
+++ b/lib/src/eval/compiler/compiler.dart
@@ -632,13 +632,14 @@ class Compiler implements BridgeDeclarationRegistry, EvalPluginRegistry {
             : (declaration as EnumDeclaration).members;
 
         if (declaration is EnumDeclaration) {
+          _ctx.enumValueIndices[libraryIndex] ??= {};
+          _ctx.enumValueIndices[libraryIndex]![declaration.name.lexeme] = {};
           for (final constant in declaration.constants) {
             if (!_topLevelGlobalIndices.containsKey(libraryIndex)) {
               _topLevelGlobalIndices[libraryIndex] = {};
               _ctx.topLevelGlobalInitializers[libraryIndex] = {};
               _ctx.topLevelVariableInferredTypes[libraryIndex] = {};
             }
-
             final name = '${declaration.name.lexeme}.${constant.name.lexeme}';
             if (_topLevelDeclarationsMap[libraryIndex]!.containsKey(name)) {
               throw CompileError(
@@ -649,7 +650,9 @@ class Compiler implements BridgeDeclarationRegistry, EvalPluginRegistry {
 
             _topLevelDeclarationsMap[libraryIndex]![name] =
                 DeclarationOrBridge(libraryIndex, declaration: constant);
-            _topLevelGlobalIndices[libraryIndex]![name] = _ctx.globalIndex++;
+            final globalIndex = _ctx.globalIndex++;
+            _topLevelGlobalIndices[libraryIndex]![name] = globalIndex;
+            _ctx.enumValueIndices[libraryIndex]![declaration.name.lexeme]![constant.name.lexeme] = globalIndex;
           }
         }
 

--- a/test/enum_test.dart
+++ b/test/enum_test.dart
@@ -97,5 +97,32 @@ void main() {
           'ShowType', {'Movie': $int(0), 'Series': $int(1)});
       runtime.executeLib('package:my_package/main.dart', 'main');
     });
+
+    test('Enum value index property from imported file', () {
+      const libSource = '''
+        enum TestEnum {
+          alpha,
+          beta
+        }
+      ''';
+
+      const mainSource = '''
+        import 'package:my_test_package/lib.dart';
+
+        int main() {
+          return TestEnum.beta.index;
+        }
+      ''';
+
+      final runtime = compiler.compileWriteAndLoad({
+        'my_test_package': {
+          'main.dart': mainSource,
+          'lib.dart': libSource,
+        }
+      });
+
+      final result = runtime.executeLib('package:my_test_package/main.dart', 'main');
+      expect(result, 1);
+    });
   });
 }


### PR DESCRIPTION
This fixes an issue where enums defined in compiled source code could not be accessed from another file. `ctx.enumValueIndices` was only being populated for bridged enums, not for enums parsed from source. This PR uses `_populateLookupTablesForDeclaration` to register source enum values and their global indices for non-bridged source files.

Closes #243 

I also added a test which failed and now succeeds. While the test now passes, I don't know if this is the idiomatic way to solve it, although it seems to be so based on how bridged enums are populated.