### PR TITLE
Fix cannot box Object type in branch resolution

### DIFF
--- a/lib/src/eval/compiler/variable.dart
+++ b/lib/src/eval/compiler/variable.dart
@@ -86,7 +86,8 @@ class Variable {
 
     ctx as CompilerContext;
 
-    if (type == CoreTypes.dynamic.ref(ctx)) {
+    if (type == CoreTypes.dynamic.ref(ctx) ||
+        type == CoreTypes.object.ref(ctx)) {
       return copyWith(type: type.copyWith(boxed: true));
     }
 

--- a/test/expression_test.dart
+++ b/test/expression_test.dart
@@ -41,6 +41,24 @@ void main() {
       }, prints('true\ntrue\ntrue\ntrue\nfalse\nfalse\ntrue\nfalse\n'));
     });
 
+    test('Is with Object type and branch', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'eval_test': {
+          'main.dart': '''
+            void main() {
+              Object x = 42;
+              if (x is int) {
+                print(x + 1);
+              }
+            }
+          ''',
+        },
+      });
+      expect(() {
+        runtime.executeLib('package:eval_test/main.dart', 'main');
+      }, prints('43\n'));
+    });
+
     test('Is num', () {
       final runtime = compiler.compileWriteAndLoad({
         'eval_test': {


### PR DESCRIPTION
Branch state resolution crashed when trying to box an Object-typed variable. Added Object to the no-op boxing path alongside dynamic.