### PR TITLE
Support Type as expression value

### DIFF
--- a/lib/src/eval/compiler/expression/expression.dart
+++ b/lib/src/eval/compiler/expression/expression.dart
@@ -8,6 +8,7 @@ import 'package:dart_eval/src/eval/compiler/expression/binary.dart';
 import 'package:dart_eval/src/eval/compiler/expression/cascade.dart';
 import 'package:dart_eval/src/eval/compiler/expression/conditional.dart';
 import 'package:dart_eval/src/eval/compiler/expression/funcexpr_invocation.dart';
+import 'package:dart_eval/src/eval/compiler/expression/function_reference.dart';
 import 'package:dart_eval/src/eval/compiler/expression/function.dart';
 import 'package:dart_eval/src/eval/compiler/expression/identifier.dart';
 import 'package:dart_eval/src/eval/compiler/expression/index.dart';
@@ -78,6 +79,8 @@ Variable compileExpression(
     return compileRethrowExpression(ctx, e);
   } else if (e is PatternAssignment) {
     return compilePatternAssignment(ctx, e);
+  } else if (e is FunctionReference) {
+    return compileFunctionReference(e, ctx);
   }
 
   throw CompileError('Unknown expression type ${e.runtimeType}');

--- a/lib/src/eval/compiler/expression/function_reference.dart
+++ b/lib/src/eval/compiler/expression/function_reference.dart
@@ -1,0 +1,36 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:dart_eval/src/eval/compiler/context.dart';
+import 'package:dart_eval/src/eval/compiler/expression/expression.dart';
+import 'package:dart_eval/src/eval/compiler/type.dart';
+import 'package:dart_eval/src/eval/compiler/variable.dart';
+import 'package:dart_eval/src/eval/runtime/runtime.dart';
+import 'package:dart_eval/src/eval/shared/types.dart';
+
+/// Handles `List<num>`, `Map<String, int>` etc. as expressions.
+Variable compileFunctionReference(FunctionReference e, CompilerContext ctx) {
+  final inner = compileExpression(e.function, ctx);
+
+  if (inner.type == CoreTypes.type.ref(ctx) && inner.concreteTypes.isNotEmpty) {
+    final baseType = inner.concreteTypes[0];
+    final typeArgs = e.typeArguments;
+    if (typeArgs != null && typeArgs.arguments.isNotEmpty) {
+      final parameterized = baseType.copyWith(
+        specifiedTypeArgs: [
+          for (final arg in typeArgs.arguments)
+            TypeRef.fromAnnotation(ctx, ctx.library, arg),
+        ],
+      );
+      ctx.pushOp(
+        PushConstantType.make(parameterized.toRuntimeType(ctx).type),
+        PushConstantType.LEN,
+      );
+      return Variable.alloc(
+        ctx,
+        CoreTypes.type.ref(ctx),
+        concreteTypes: [parameterized],
+      );
+    }
+  }
+
+  return inner;
+}

--- a/lib/src/eval/compiler/reference.dart
+++ b/lib/src/eval/compiler/reference.dart
@@ -768,8 +768,12 @@ Variable _declarationToVariable(
     if (bridge is BridgeClassDef) {
       final type = TypeRef.fromBridgeTypeRef(ctx, bridge.type.type);
 
-      return Variable(
-        -1,
+      ctx.pushOp(
+        PushConstantType.make(type.toRuntimeType(ctx).type),
+        PushConstantType.LEN,
+      );
+      return Variable.alloc(
+        ctx,
         CoreTypes.type.ref(ctx),
         concreteTypes: [type],
         methodOffset: DeferredOrOffset(file: type.file, name: '${type.name}.'),
@@ -779,8 +783,13 @@ Variable _declarationToVariable(
 
     if (bridge is BridgeEnumDef) {
       final type = TypeRef.fromBridgeTypeRef(ctx, bridge.type);
-      return Variable(
-        -1,
+
+      ctx.pushOp(
+        PushConstantType.make(type.toRuntimeType(ctx).type),
+        PushConstantType.LEN,
+      );
+      return Variable.alloc(
+        ctx,
         CoreTypes.type.ref(ctx),
         concreteTypes: [type],
         methodOffset: DeferredOrOffset(
@@ -854,8 +863,12 @@ Variable _declarationToVariable(
       offset = DeferredOrOffset(file: decOrBridge.sourceLib, name: '$name.');
     }
 
-    return Variable(
-      -1,
+    ctx.pushOp(
+      PushConstantType.make(returnType.toRuntimeType(ctx).type),
+      PushConstantType.LEN,
+    );
+    return Variable.alloc(
+      ctx,
       CoreTypes.type.ref(ctx),
       concreteTypes: [returnType],
       methodOffset: offset,

--- a/test/class_test.dart
+++ b/test/class_test.dart
@@ -439,6 +439,62 @@ void main() {
       }, prints('true\nfalse\ntrue\n'));
     });
 
+    test('Type used as expression value', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            void main() {
+              Type t = int;
+              print(t == 1.runtimeType);
+            }
+          ''',
+        },
+      });
+
+      expect(() {
+        runtime.executeLib('package:example/main.dart', 'main');
+      }, prints('true\n'));
+    });
+
+    test('Type passed as function argument', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            String describeType(Type t) {
+              return t.toString();
+            }
+            void main() {
+              print(describeType(int));
+            }
+          ''',
+        },
+      });
+
+      expect(() {
+        runtime.executeLib('package:example/main.dart', 'main');
+      }, prints(anything));
+    });
+
+    test('User-defined class used as Type value', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            class Foo {
+              Foo();
+            }
+            void main() {
+              Type t = Foo;
+              print(t == Foo().runtimeType);
+            }
+          ''',
+        },
+      });
+
+      expect(() {
+        runtime.executeLib('package:example/main.dart', 'main');
+      }, prints('true\n'));
+    });
+
     test('Modifying static class field', () {
       final runtime = compiler.compileWriteAndLoad({
         'example': {

--- a/test/expression_test.dart
+++ b/test/expression_test.dart
@@ -417,5 +417,23 @@ void main() {
         runtime.executeLib('package:example/main.dart', 'main');
       }, prints('True executed\ntrue\nFalse executed\nfalse\n'));
     });
+
+    test('parameterized type literal as variable initializer', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            void main() {
+              var t = List<int>;
+              print(t == List);
+            }
+          ''',
+        },
+      });
+
+      expect(
+        () => runtime.executeLib('package:example/main.dart', 'main'),
+        prints('true\n'),
+      );
+    });
   });
 }


### PR DESCRIPTION
Before this, referencing a type name in expression position crashed at runtime because the compiler never pushed the value onto the stack