### PR TITLE
Fix custom operator dispatch missing receiver

### DIFF
--- a/lib/src/eval/compiler/expression/method_invocation.dart
+++ b/lib/src/eval/compiler/expression/method_invocation.dart
@@ -396,6 +396,7 @@ Variable _invokeWithTarget(
     final op = InvokeDynamic.make(
       L.boxIfNeeded(ctx).scopeFrameOffset,
       ctx.constantPool.addOrGet(e.methodName.name),
+      hasReceiver: dec0?.isBridge != true,
     );
     ctx.pushOp(op, InvokeDynamic.len(op));
   }

--- a/lib/src/eval/compiler/helpers/invoke.dart
+++ b/lib/src/eval/compiler/helpers/invoke.dart
@@ -66,6 +66,12 @@ extension Invoke on Variable {
         CheckEq.LEN,
       );
     } else {
+      final isInstanceClass = type != CoreTypes.dynamic.ref(ctx) &&
+          ctx.topLevelDeclarationsMap[type.file]?[type.name]?.isBridge == false;
+
+      if (isInstanceClass) {
+        ctx.pushOp(PushArg.make($this.scopeFrameOffset), PushArg.LEN);
+      }
       for (final invokeArg in args0) {
         ctx.pushOp(PushArg.make(invokeArg.scopeFrameOffset), PushArg.LEN);
       }
@@ -73,6 +79,7 @@ extension Invoke on Variable {
       final invokeOp = InvokeDynamic.make(
         $this.scopeFrameOffset,
         ctx.constantPool.addOrGet(method),
+        hasReceiver: isInstanceClass,
       );
       ctx.pushOp(invokeOp, InvokeDynamic.len(invokeOp));
     }

--- a/lib/src/eval/compiler/helpers/tearoff.dart
+++ b/lib/src/eval/compiler/helpers/tearoff.dart
@@ -127,6 +127,7 @@ extension TearOff on Variable {
       final invokeOp = InvokeDynamic.make(
         $target.scopeFrameOffset,
         ctx.constantPool.addOrGet(methodName),
+        hasReceiver: true,
       );
       ctx.pushOp(invokeOp, InvokeDynamic.len(invokeOp));
     } else {

--- a/lib/src/eval/runtime/ops/objects.dart
+++ b/lib/src/eval/runtime/ops/objects.dart
@@ -5,15 +5,21 @@ part of '../runtime.dart';
 class InvokeDynamic implements EvcOp {
   InvokeDynamic(Runtime runtime)
     : _location = runtime._readInt16(),
-      _methodIdx = runtime._readInt32();
+      _methodIdx = runtime._readInt32(),
+      _hasReceiver = runtime._readUint8() == 1;
 
-  InvokeDynamic.make(this._location, this._methodIdx);
+  InvokeDynamic.make(
+    this._location,
+    this._methodIdx, {
+    required bool hasReceiver,
+  }) : _hasReceiver = hasReceiver;
 
   final int _location;
   final int _methodIdx;
+  final bool _hasReceiver;
 
   static int len(InvokeDynamic s) {
-    return Evc.BASE_OPLEN + Evc.I16_LEN + Evc.I32_LEN;
+    return Evc.BASE_OPLEN + Evc.I16_LEN + Evc.I32_LEN + Evc.I8_LEN;
   }
 
   @override
@@ -29,8 +35,7 @@ class InvokeDynamic implements EvcOp {
           object = object.evalSuperclass;
           continue;
         }
-        // Ensure `this` is the first arg (some callers already prepend it)
-        if (runtime.args.isEmpty || !identical(runtime.args[0], object)) {
+        if (!_hasReceiver) {
           runtime.args = [object, ...runtime.args];
         }
         runtime.callStack.add(runtime._prOffset);

--- a/lib/src/eval/runtime/ops/objects.dart
+++ b/lib/src/eval/runtime/ops/objects.dart
@@ -29,6 +29,10 @@ class InvokeDynamic implements EvcOp {
           object = object.evalSuperclass;
           continue;
         }
+        // Ensure `this` is the first arg (some callers already prepend it)
+        if (runtime.args.isEmpty || !identical(runtime.args[0], object)) {
+          runtime.args = [object, ...runtime.args];
+        }
         runtime.callStack.add(runtime._prOffset);
         runtime.catchStack.add([]);
         runtime._prOffset = offset;

--- a/lib/src/eval/runtime/runtime.dart
+++ b/lib/src/eval/runtime/runtime.dart
@@ -90,7 +90,7 @@ class _UnloadedEnumValues {
 ///
 class Runtime {
   /// The current runtime version code
-  static const int versionCode = 81;
+  static const int versionCode = 82;
 
   /// Construct a runtime from EVC bytecode. When possible, use the
   /// [Runtime.ofProgram] constructor instead to reduce loading time.
@@ -546,6 +546,7 @@ class Runtime {
           Evc.OP_INVOKE_DYNAMIC,
           ...Evc.i16b(op._location),
           ...Evc.i32b(op._methodIdx),
+          op._hasReceiver ? 1 : 0,
         ];
       case SetObjectProperty op:
         return [

--- a/test/operator_test.dart
+++ b/test/operator_test.dart
@@ -90,5 +90,62 @@ void main() {
         $int(2),
       ]);
     }, skip: true);
+
+    test('operator [] dispatches to the correct receiver', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'operator_test': {
+          'main.dart': '''
+            class A {
+              final List<String> _items;
+              A() : _items = ['a', 'b', 'c'];
+
+              String operator [](int i) => _items[i];
+            }
+
+            void main() {
+              final a = A();
+              print(a[0]);
+              print(a[2]);
+            }
+          ''',
+        },
+      });
+
+      expect(
+        () => runtime.executeLib('package:operator_test/main.dart', 'main'),
+        prints('a\nc\n'),
+      );
+    });
+
+    test('custom class operators dispatch to the correct receiver', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'operator_test': {
+          'main.dart': '''
+            class A {
+              final int v;
+              A(this.v);
+              A operator +(A o) => A(v + o.v);
+              A operator *(A o) => A(v * o.v);
+              A operator /(A o) => A(v ~/ o.v);
+              A operator %(A o) => A(v % o.v);
+            }
+
+            void main() {
+              final a = A(10);
+              final b = A(3);
+              print((a + b).v);
+              print((a * b).v);
+              print((a / b).v);
+              print((a % b).v);
+            }
+          ''',
+        },
+      });
+
+      expect(
+        () => runtime.executeLib('package:operator_test/main.dart', 'main'),
+        prints('13\n30\n3\n1\n'),
+      );
+    });
   });
 }


### PR DESCRIPTION
Custom operators on eval-defined classes ([], []=, +, *, /, %, etc.) crash because InvokeDynamic doesn't pass the instance as the first arg.