### PR TITLE
fix: box string argument in compileSymbolLiteral before InvokeExternal

### DIFF
--- a/lib/src/eval/compiler/expression/symbol.dart
+++ b/lib/src/eval/compiler/expression/symbol.dart
@@ -11,7 +11,7 @@ Variable compileSymbolLiteral(SymbolLiteral l, CompilerContext ctx) {
   if (name.startsWith('_')) {
     name = name.substring(1);
   }
-  BuiltinValue(stringval: name).push(ctx).pushArg(ctx);
+  BuiltinValue(stringval: name).push(ctx).boxIfNeeded(ctx).pushArg(ctx);
   ctx.pushOp(
     InvokeExternal.make(
       ctx.bridgeStaticFunctionIndices[ctx

--- a/test/symbol_test.dart
+++ b/test/symbol_test.dart
@@ -1,0 +1,78 @@
+import 'package:test/test.dart';
+import 'package:dart_eval/dart_eval.dart';
+
+void main() {
+  group('Symbol literal tests', () {
+    late Compiler compiler;
+
+    setUp(() {
+      compiler = Compiler();
+    });
+
+    test('Simple symbol literal', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            void main() {
+              print(#hello);
+            }
+          ''',
+        },
+      });
+
+      expect(() {
+        runtime.executeLib('package:example/main.dart', 'main');
+      }, prints('Symbol("hello")\n'));
+    });
+
+    test('Dotted symbol literal', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            void main() {
+              print(#foo.bar);
+            }
+          ''',
+        },
+      });
+
+      expect(() {
+        runtime.executeLib('package:example/main.dart', 'main');
+      }, prints('Symbol("foo.bar")\n'));
+    });
+
+    test('Private symbol literal strips leading underscore', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            void main() {
+              print(#_private);
+            }
+          ''',
+        },
+      });
+
+      expect(() {
+        runtime.executeLib('package:example/main.dart', 'main');
+      }, prints('Symbol("private")\n'));
+    });
+
+    test('Symbol literal can be assigned and compared', () {
+      final runtime = compiler.compileWriteAndLoad({
+        'example': {
+          'main.dart': '''
+            void main() {
+              var s = #test;
+              print(s == #test);
+              print(s == #other);
+            }
+          ''',
+        },
+      });
+
+      expect(() {
+        runtime.executeLib('package:example/main.dart', 'main');
+      }, prints('true\nfalse\n'));
+    });
+  });
+}


### PR DESCRIPTION
Fixes symbol compilation by boxing the string argument before InvokeExternal.