### PR TITLE
fix(bindgen): generate constructors for abstract bridge classes

### DIFF
--- a/lib/src/eval/bindgen/statics.dart
+++ b/lib/src/eval/bindgen/statics.dart
@@ -11,7 +11,9 @@ String $constructors(
 }) {
   return element.constructors
       .where(
-        (cstr) => !cstr.isPrivate && (cstr.isFactory || !element.isAbstract),
+        (cstr) =>
+            !cstr.isPrivate &&
+            (cstr.isFactory || !element.isAbstract || isBridge),
       )
       .map((e) => _$constructor(ctx, element, e, isBridge: isBridge))
       .join('\n');

--- a/test/bridge_lib.dart
+++ b/test/bridge_lib.dart
@@ -157,6 +157,94 @@ class $TestClass extends TestClass with $Bridge {
   set someNumber(int someNumber) => $_set('someNumber', $int(someNumber));
 }
 
+abstract class AbstractTestClass {
+  AbstractTestClass(this.baseValue);
+
+  final int baseValue;
+
+  int compute(int input);
+}
+
+class $AbstractTestClass$bridge extends AbstractTestClass with $Bridge {
+  $AbstractTestClass$bridge(super.baseValue);
+
+  static $AbstractTestClass$bridge $construct(
+    Runtime runtime,
+    $Value? target,
+    List<$Value?> args,
+  ) => $AbstractTestClass$bridge(args[0]!.$value);
+
+  static const $type = BridgeTypeRef(
+    BridgeTypeSpec('package:bridge_lib/bridge_lib.dart', 'AbstractTestClass'),
+  );
+
+  static const $declaration = BridgeClassDef(
+    BridgeClassType($type, isAbstract: true),
+    constructors: {
+      '': BridgeConstructorDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation($type),
+          params: [
+            BridgeParameter(
+              'baseValue',
+              BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.int)),
+              false,
+            ),
+          ],
+          namedParams: [],
+        ),
+      ),
+    },
+    methods: {
+      'compute': BridgeMethodDef(
+        BridgeFunctionDef(
+          returns: BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.int)),
+          params: [
+            BridgeParameter(
+              'input',
+              BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.int)),
+              false,
+            ),
+          ],
+          namedParams: [],
+        ),
+      ),
+    },
+    getters: {},
+    setters: {},
+    fields: {
+      'baseValue': BridgeFieldDef(
+        BridgeTypeAnnotation(BridgeTypeRef(CoreTypes.int)),
+      ),
+    },
+    bridge: true,
+  );
+
+  @override
+  $Value? $bridgeGet(String identifier) {
+    switch (identifier) {
+      case 'baseValue':
+        return $int(super.baseValue);
+    }
+    throw UnimplementedError(
+      'Cannot get property "$identifier" on abstract class AbstractTestClass',
+    );
+  }
+
+  @override
+  void $bridgeSet(String identifier, $Value value) {
+    throw UnimplementedError(
+      'Cannot set property "$identifier" on abstract class AbstractTestClass',
+    );
+  }
+
+  @override
+  int compute(int input) => $_invoke('compute', [$int(input)]);
+
+  @override
+  int get baseValue => $_get('baseValue');
+}
+
 enum TestEnum { one, two, three }
 
 class $TestEnum implements $Instance {

--- a/test/bridge_test.dart
+++ b/test/bridge_test.dart
@@ -366,6 +366,130 @@ void main() {
       expect(caughtException.toString(), contains('Bridge error'));
     });
 
+    test('Subclassing an abstract bridge class in the runtime', () {
+      compiler.defineBridgeClasses([
+        $TestClass.$declaration,
+        $AbstractTestClass$bridge.$declaration,
+      ]);
+
+      final program = compiler.compile({
+        'example': {
+          'main.dart': '''
+            import 'package:bridge_lib/bridge_lib.dart';
+
+            class MyAbstractSub extends AbstractTestClass {
+              MyAbstractSub(int baseValue) : super(baseValue);
+
+              @override
+              int compute(int input) {
+                return baseValue + input * 2;
+              }
+            }
+
+            int main() {
+              final instance = MyAbstractSub(10);
+              return instance.compute(5);
+            }
+          ''',
+        },
+      });
+
+      final runtime = Runtime.ofProgram(program);
+
+      runtime.registerBridgeFunc(
+        'package:bridge_lib/bridge_lib.dart',
+        'AbstractTestClass.',
+        $AbstractTestClass$bridge.$construct,
+        isBridge: true,
+      );
+
+      expect(runtime.executeLib('package:example/main.dart', 'main'), 20);
+    });
+
+    test('Subclassing an abstract bridge class with required super params', () {
+      compiler.defineBridgeClasses([
+        $TestClass.$declaration,
+        $AbstractTestClass$bridge.$declaration,
+      ]);
+
+      final program = compiler.compile({
+        'example': {
+          'main.dart': '''
+            import 'package:bridge_lib/bridge_lib.dart';
+
+            class MultiplierSub extends AbstractTestClass {
+              final int multiplier;
+
+              MultiplierSub({required int baseValue, required this.multiplier})
+                  : super(baseValue);
+
+              @override
+              int compute(int input) {
+                return baseValue * multiplier + input;
+              }
+            }
+
+            int main() {
+              final instance = MultiplierSub(baseValue: 5, multiplier: 3);
+              return instance.compute(7);
+            }
+          ''',
+        },
+      });
+
+      final runtime = Runtime.ofProgram(program);
+
+      runtime.registerBridgeFunc(
+        'package:bridge_lib/bridge_lib.dart',
+        'AbstractTestClass.',
+        $AbstractTestClass$bridge.$construct,
+        isBridge: true,
+      );
+
+      expect(runtime.executeLib('package:example/main.dart', 'main'), 22);
+    });
+
+    test('Subclassing an abstract bridge class and using from outside', () {
+      compiler.defineBridgeClasses([
+        $AbstractTestClass$bridge.$declaration,
+      ]);
+
+      final program = compiler.compile({
+        'example': {
+          'main.dart': '''
+            import 'package:bridge_lib/bridge_lib.dart';
+
+            class DoublerSub extends AbstractTestClass {
+              DoublerSub(int baseValue) : super(baseValue);
+
+              @override
+              int compute(int input) {
+                return input * 2 + baseValue;
+              }
+            }
+
+            AbstractTestClass main() {
+              return DoublerSub(100);
+            }
+          ''',
+        },
+      });
+
+      final runtime = Runtime.ofProgram(program);
+
+      runtime.registerBridgeFunc(
+        'package:bridge_lib/bridge_lib.dart',
+        'AbstractTestClass.',
+        $AbstractTestClass$bridge.$construct,
+        isBridge: true,
+      );
+
+      final res = runtime.executeLib('package:example/main.dart', 'main');
+
+      expect(res is AbstractTestClass, true);
+      expect((res as AbstractTestClass).compute(3), 106);
+    });
+
     test('Void async function in a subclassed bridge class', () async {
       compiler.defineBridgeClasses([$TestClass.$declaration]);
 


### PR DESCRIPTION
The $constructors filter in bindgen was excluding non-factory constructors for abstract classes, but bridge classes themselves are concrete - even when the class they wrap 
is abstract. This caused an UnimplementedError when instantiat
ing subclasses of an abstract bridge class in the VM.
    
Added `|| isBridge` to the filter so bridge class constructors are always generated regardless of the source 
class's abstractness.
    
Closes #275